### PR TITLE
Breakout events into AddressablesLoaded category

### DIFF
--- a/Winch/Core/API/DredgeEvent.cs
+++ b/Winch/Core/API/DredgeEvent.cs
@@ -1,156 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
-using UnityEngine.ResourceManagement.AsyncOperations;
+using Winch.Core.Events.Addressables;
 
 namespace Winch.Core.API
 {
     public static class DredgeEvent
     {
-        public class AddressablesLoadedEventArgs<T> : EventArgs
-        {
-            public AsyncOperationHandle<IList<T>> Handle;
-
-            public AddressablesLoadedEventArgs(AsyncOperationHandle<IList<T>> handle)
-            {
-                Handle = handle;
-            }
-        }
-        public delegate void AddressablesLoadedEventHandler<T>(object sender, AddressablesLoadedEventArgs<T> e);
-
-
+        public static AddressableEvents AddressableEvents = new AddressableEvents();
 
         public static event EventHandler ManagersLoaded;
-        internal static void TriggerManagersLoaded()
+        public static void TriggerManagersLoaded()
         {
             WinchCore.Log.Debug("Triggered ManagersLoaded event");
             ManagersLoaded?.Invoke(null, null);
         }
-
-
-
-        public static event AddressablesLoadedEventHandler<AchievementData> BeforeAchievementsLoaded;
-        public static event AddressablesLoadedEventHandler<AchievementData> AchievementsLoaded;
-        internal static void TriggerAchievementsLoaded(object sender, AsyncOperationHandle<IList<AchievementData>> loadHandle, bool prefixTrigger)
-        {
-            WinchCore.Log.Debug($"Triggered AchievementsLoaded type event: {loadHandle.Result.Count} elements (Prefix: {prefixTrigger})");
-            AddressablesLoadedEventArgs<AchievementData> args = new AddressablesLoadedEventArgs<AchievementData>(loadHandle);
-            if (prefixTrigger)
-                BeforeAchievementsLoaded?.Invoke(sender, args);
-            else
-                AchievementsLoaded?.Invoke(sender, args);
-        }
-
-
-
-        public static event AddressablesLoadedEventHandler<GridConfiguration> BeforeGridConfigsLoaded;
-        public static event AddressablesLoadedEventHandler<GridConfiguration> GridConfigsLoaded;
-        internal static void TriggerGridConfigsLoaded(object sender, AsyncOperationHandle<IList<GridConfiguration>> loadHandle, bool prefixTrigger)
-        {
-            WinchCore.Log.Debug($"Triggered GridConfigsLoaded type event: {loadHandle.Result.Count} elements (Prefix: {prefixTrigger})");
-            AddressablesLoadedEventArgs<GridConfiguration> args = new AddressablesLoadedEventArgs<GridConfiguration>(loadHandle);
-            if (prefixTrigger)
-                BeforeGridConfigsLoaded?.Invoke(sender, args);
-            else
-                GridConfigsLoaded?.Invoke(sender, args);
-        }
-
-
-
-        public static event AddressablesLoadedEventHandler<ItemData> BeforeItemsLoaded;
-        public static event AddressablesLoadedEventHandler<ItemData> ItemsLoaded;
-        internal static void TriggerItemsLoaded(object sender, AsyncOperationHandle<IList<ItemData>> loadHandle, bool prefixTrigger)
-        {
-            WinchCore.Log.Debug($"Triggered ItemsLoaded type event: {loadHandle.Result.Count} elements (Prefix: {prefixTrigger})");
-            AddressablesLoadedEventArgs<ItemData> args = new AddressablesLoadedEventArgs<ItemData>(loadHandle);
-            if (prefixTrigger)
-                BeforeItemsLoaded?.Invoke(sender, args);
-            else
-                ItemsLoaded?.Invoke(sender, args);
-        }
-
-
-
-        public static event AddressablesLoadedEventHandler<MapMarkerData> BeforeMapMarkersLoaded;
-        public static event AddressablesLoadedEventHandler<MapMarkerData> MapMarkersLoaded;
-        internal static void TriggerMapMarkersLoaded(object sender, AsyncOperationHandle<IList<MapMarkerData>> loadHandle, bool prefixTrigger)
-        {
-            WinchCore.Log.Debug($"Triggered MapMarkersLoaded type event: {loadHandle.Result.Count} elements (Prefix: {prefixTrigger})");
-            AddressablesLoadedEventArgs<MapMarkerData> args = new AddressablesLoadedEventArgs<MapMarkerData>(loadHandle);
-            if (prefixTrigger)
-                BeforeMapMarkersLoaded?.Invoke(sender, args);
-            else
-                MapMarkersLoaded?.Invoke(sender, args);
-        }
-
-
-
-        public static event AddressablesLoadedEventHandler<QuestData> BeforeQuestsLoaded;
-        public static event AddressablesLoadedEventHandler<QuestData> QuestsLoaded;
-        internal static void TriggerQuestsLoaded(object sender, AsyncOperationHandle<IList<QuestData>> loadHandle, bool prefixTrigger)
-        {
-            WinchCore.Log.Debug($"Triggered QuestsLoaded type event: {loadHandle.Result.Count} elements (Prefix: {prefixTrigger})");
-            AddressablesLoadedEventArgs<QuestData> args = new AddressablesLoadedEventArgs<QuestData>(loadHandle);
-            if (prefixTrigger)
-                BeforeQuestsLoaded?.Invoke(sender, args);
-            else
-                QuestsLoaded?.Invoke(sender, args);
-        }
-
-
-
-        public static event AddressablesLoadedEventHandler<QuestGridConfig> BeforeQuestGridLoaded;
-        public static event AddressablesLoadedEventHandler<QuestGridConfig> QuestGridLoaded;
-        internal static void TriggerQuestGridLoaded(object sender, AsyncOperationHandle<IList<QuestGridConfig>> loadHandle, bool prefixTrigger)
-        {
-            WinchCore.Log.Debug($"Triggered QuestGridLoaded type event: {loadHandle.Result.Count} elements (Prefix: {prefixTrigger})");
-            AddressablesLoadedEventArgs<QuestGridConfig> args = new AddressablesLoadedEventArgs<QuestGridConfig>(loadHandle);
-            if (prefixTrigger)
-                BeforeQuestGridLoaded?.Invoke(sender, args);
-            else
-                QuestGridLoaded?.Invoke(sender, args);
-        }
-
-
-
-        public static event AddressablesLoadedEventHandler<UpgradeData> BeforeUpgradesLoaded;
-        public static event AddressablesLoadedEventHandler<UpgradeData> UpgradesLoaded;
-        internal static void TriggerUpgradesLoaded(object sender, AsyncOperationHandle<IList<UpgradeData>> loadHandle, bool prefixTrigger)
-        {
-            WinchCore.Log.Debug($"Triggered UpgradesLoaded type event: {loadHandle.Result.Count} elements (Prefix: {prefixTrigger})");
-            AddressablesLoadedEventArgs<UpgradeData> args = new AddressablesLoadedEventArgs<UpgradeData>(loadHandle);
-            if (prefixTrigger)
-                BeforeUpgradesLoaded?.Invoke(sender, args);
-            else
-                UpgradesLoaded?.Invoke(sender, args);
-        }
-
-
-
-        public static event AddressablesLoadedEventHandler<WeatherData> BeforeWeatherDataLoaded;
-        public static event AddressablesLoadedEventHandler<WeatherData> WeatherDataLoaded;
-        internal static void TriggerWeatherDataLoaded(object sender, AsyncOperationHandle<IList<WeatherData>> loadHandle, bool prefixTrigger)
-        {
-            WinchCore.Log.Debug($"Triggered WeatherDataLoaded type event: {loadHandle.Result.Count} elements (Prefix: {prefixTrigger})");
-            AddressablesLoadedEventArgs<WeatherData> args = new AddressablesLoadedEventArgs<WeatherData>(loadHandle);
-            if (prefixTrigger)
-                BeforeWeatherDataLoaded?.Invoke(sender, args);
-            else
-                WeatherDataLoaded?.Invoke(sender, args);
-        }
-
-
-
-        public static event AddressablesLoadedEventHandler<WorldEventData> BeforeWorldEventsLoaded;
-        public static event AddressablesLoadedEventHandler<WorldEventData> WorldEventsLoaded;
-        internal static void TriggerWorldEventsLoaded(object sender, AsyncOperationHandle<IList<WorldEventData>> loadHandle, bool prefixTrigger)
-        {
-            WinchCore.Log.Debug($"Triggered WorldEventsLoaded type event: {loadHandle.Result.Count} elements (Prefix: {prefixTrigger})");
-            AddressablesLoadedEventArgs<WorldEventData> args = new AddressablesLoadedEventArgs<WorldEventData>(loadHandle);
-            if (prefixTrigger)
-                BeforeWorldEventsLoaded?.Invoke(sender, args);
-            else
-                WorldEventsLoaded?.Invoke(sender, args);
-        }
     }
-
 }

--- a/Winch/Core/API/Events/Addressables/AddressableEvents.cs
+++ b/Winch/Core/API/Events/Addressables/AddressableEvents.cs
@@ -1,0 +1,23 @@
+﻿namespace Winch.Core.Events.Addressables
+{
+    public class AddressableEvents
+    {
+        public AddressablesLoadedHook<AchievementData> AchievementsLoaded = new AddressablesLoadedHook<AchievementData>();
+
+        public AddressablesLoadedHook<GridConfiguration> GridConfigsLoaded = new AddressablesLoadedHook<GridConfiguration>();
+
+        public AddressablesLoadedHook<ItemData> ItemsLoaded = new AddressablesLoadedHook<ItemData>();
+
+        public AddressablesLoadedHook<MapMarkerData> MapMarkersLoaded = new AddressablesLoadedHook<MapMarkerData>();
+
+        public AddressablesLoadedHook<QuestData> QuestsLoaded = new AddressablesLoadedHook<QuestData>();
+
+        public AddressablesLoadedHook<QuestGridConfig> QuestGridConfigsLoaded = new AddressablesLoadedHook<QuestGridConfig>();
+
+        public AddressablesLoadedHook<UpgradeData> UpgradesLoaded = new AddressablesLoadedHook<UpgradeData>();
+
+        public AddressablesLoadedHook<WeatherData> WeatherDataLoaded = new AddressablesLoadedHook<WeatherData>();
+
+        public AddressablesLoadedHook<WorldEventData> WorldEventsLoaded = new AddressablesLoadedHook<WorldEventData>();
+    }
+}

--- a/Winch/Core/API/Events/Addressables/AddressablesLoadedEventArgs.cs
+++ b/Winch/Core/API/Events/Addressables/AddressablesLoadedEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using UnityEngine.ResourceManagement.AsyncOperations;
+
+namespace Winch.Core.Events.Addressables
+{
+    public struct AddressablesLoadedEventArgs<T>
+    {
+        public AsyncOperationHandle<IList<T>> Handle;
+
+        public AddressablesLoadedEventArgs(AsyncOperationHandle<IList<T>> handle)
+        {
+            Handle = handle;
+        }
+    }
+}

--- a/Winch/Core/API/Events/Addressables/AddressablesLoadedEventHandler.cs
+++ b/Winch/Core/API/Events/Addressables/AddressablesLoadedEventHandler.cs
@@ -1,0 +1,4 @@
+﻿namespace Winch.Core.Events.Addressables
+{
+    public delegate void AddressablesLoadedEventHandler<T>(object sender, AddressablesLoadedEventArgs<T> e);
+}

--- a/Winch/Core/API/Events/Addressables/AddressablesLoadedHook.cs
+++ b/Winch/Core/API/Events/Addressables/AddressablesLoadedHook.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine.ResourceManagement.AsyncOperations;
+
+namespace Winch.Core.Events.Addressables
+{
+    public class AddressablesLoadedHook<T>
+    {
+        public event AddressablesLoadedEventHandler<T> Before;
+        public event AddressablesLoadedEventHandler<T> On;
+
+        public void Trigger(object sender, AsyncOperationHandle<IList<T>> handle, bool prefix)
+        {
+            WinchCore.Log.Debug($"Triggered {typeof(T)} type event: {handle.Result.Count} elements (Prefix: {prefix})");
+            try
+            {
+                var args = new AddressablesLoadedEventArgs<T>(handle);
+                if (prefix)
+                    Before?.Invoke(sender, args);
+                else
+                    On?.Invoke(sender, args);
+            }
+            catch (Exception ex)
+            {
+                WinchCore.Log.Error($"Failed to trigger {typeof(T)} type event: {ex}");
+            }
+
+        }
+    }
+}

--- a/Winch/Patches/API/AchievementLoadPatcher.cs
+++ b/Winch/Patches/API/AchievementLoadPatcher.cs
@@ -11,12 +11,12 @@ namespace Winch.Patches.API
     {
         public static void Prefix(AchievementManager __instance, AsyncOperationHandle<IList<AchievementData>> handle)
         {
-            DredgeEvent.TriggerAchievementsLoaded(__instance, handle, true);
+            DredgeEvent.AddressableEvents.AchievementsLoaded.Trigger(__instance, handle, true);
         }
 
         public static void Postfix(AchievementManager __instance, AsyncOperationHandle<IList<AchievementData>> handle)
         {
-            DredgeEvent.TriggerAchievementsLoaded(__instance, handle, false);
+            DredgeEvent.AddressableEvents.AchievementsLoaded.Trigger(__instance, handle, false);
         }
     }
 }

--- a/Winch/Patches/API/GridConfigsLoadPatcher.cs
+++ b/Winch/Patches/API/GridConfigsLoadPatcher.cs
@@ -11,12 +11,12 @@ namespace Winch.Patches.API
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<GridConfiguration>> handle)
         {
-            DredgeEvent.TriggerGridConfigsLoaded(__instance, handle, true);
+            DredgeEvent.AddressableEvents.GridConfigsLoaded.Trigger(__instance, handle, true);
         }
 
         public static void Postfix(DataLoader __instance, AsyncOperationHandle<IList<GridConfiguration>> handle)
         {
-            DredgeEvent.TriggerGridConfigsLoaded(__instance, handle, false);
+            DredgeEvent.AddressableEvents.GridConfigsLoaded.Trigger(__instance, handle, false);
         }
     }
 }

--- a/Winch/Patches/API/ItemLoadPatcher.cs
+++ b/Winch/Patches/API/ItemLoadPatcher.cs
@@ -11,12 +11,12 @@ namespace Winch.Patches.API
     {
         public static void Prefix(ItemManager __instance, AsyncOperationHandle<IList<ItemData>> handle)
         {
-            DredgeEvent.TriggerItemsLoaded(__instance, handle, true);
+            DredgeEvent.AddressableEvents.ItemsLoaded.Trigger(__instance, handle, true);
         }
 
         public static void Postfix(ItemManager __instance, AsyncOperationHandle<IList<ItemData>> handle)
         {
-            DredgeEvent.TriggerItemsLoaded(__instance, handle, false);
+            DredgeEvent.AddressableEvents.ItemsLoaded.Trigger(__instance, handle, false);
         }
     }
 }

--- a/Winch/Patches/API/MapMarkerLoadPatcher.cs
+++ b/Winch/Patches/API/MapMarkerLoadPatcher.cs
@@ -11,12 +11,12 @@ namespace Winch.Patches.API
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<MapMarkerData>> handle)
         {
-            DredgeEvent.TriggerMapMarkersLoaded(__instance, handle, true);
+            DredgeEvent.AddressableEvents.MapMarkersLoaded.Trigger(__instance, handle, true);
         }
 
         public static void Postfix(DataLoader __instance, AsyncOperationHandle<IList<MapMarkerData>> handle)
         {
-            DredgeEvent.TriggerMapMarkersLoaded(__instance, handle, false);
+            DredgeEvent.AddressableEvents.MapMarkersLoaded.Trigger(__instance, handle, false);
         }
     }
 }

--- a/Winch/Patches/API/QuestGridLoadPatcher.cs
+++ b/Winch/Patches/API/QuestGridLoadPatcher.cs
@@ -11,12 +11,12 @@ namespace Winch.Patches.API
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<QuestGridConfig>> handle)
         {
-            DredgeEvent.TriggerQuestGridLoaded(__instance, handle, true);
+            DredgeEvent.AddressableEvents.QuestGridConfigsLoaded.Trigger(__instance, handle, true);
         }
 
         public static void Postfix(DataLoader __instance, AsyncOperationHandle<IList<QuestGridConfig>> handle)
         {
-            DredgeEvent.TriggerQuestGridLoaded(__instance, handle, false);
+            DredgeEvent.AddressableEvents.QuestGridConfigsLoaded.Trigger(__instance, handle, false);
         }
     }
 }

--- a/Winch/Patches/API/QuestLoadPatcher.cs
+++ b/Winch/Patches/API/QuestLoadPatcher.cs
@@ -11,12 +11,12 @@ namespace Winch.Patches.API
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<QuestData>> handle)
         {
-            DredgeEvent.TriggerQuestsLoaded(__instance, handle, true);
+            DredgeEvent.AddressableEvents.QuestsLoaded.Trigger(__instance, handle, true);
         }
 
         public static void Postfix(DataLoader __instance, AsyncOperationHandle<IList<QuestData>> handle)
         {
-            DredgeEvent.TriggerQuestsLoaded(__instance, handle, false);
+            DredgeEvent.AddressableEvents.QuestsLoaded.Trigger(__instance, handle, false);
         }
     }
 }

--- a/Winch/Patches/API/UpgradeLoadPatcher.cs
+++ b/Winch/Patches/API/UpgradeLoadPatcher.cs
@@ -11,12 +11,12 @@ namespace Winch.Patches.API
     {
         public static void Prefix(UpgradeManager __instance, AsyncOperationHandle<IList<UpgradeData>> handle)
         {
-            DredgeEvent.TriggerUpgradesLoaded(__instance, handle, true);
+            DredgeEvent.AddressableEvents.UpgradesLoaded.Trigger(__instance, handle, true);
         }
 
         public static void Postfix(UpgradeManager __instance, AsyncOperationHandle<IList<UpgradeData>> handle)
         {
-            DredgeEvent.TriggerUpgradesLoaded(__instance, handle, false);
+            DredgeEvent.AddressableEvents.UpgradesLoaded.Trigger(__instance, handle, false);
         }
     }
 }

--- a/Winch/Patches/API/WeatherDataLoadPatcher.cs
+++ b/Winch/Patches/API/WeatherDataLoadPatcher.cs
@@ -11,12 +11,12 @@ namespace Winch.Patches.API
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<WeatherData>> handle)
         {
-            DredgeEvent.TriggerWeatherDataLoaded(__instance, handle, true);
+            DredgeEvent.AddressableEvents.WeatherDataLoaded.Trigger(__instance, handle, true);
         }
 
         public static void Postfix(DataLoader __instance, AsyncOperationHandle<IList<WeatherData>> handle)
         {
-            DredgeEvent.TriggerWeatherDataLoaded(__instance, handle, false);
+            DredgeEvent.AddressableEvents.WeatherDataLoaded.Trigger(__instance, handle, false);
         }
     }
 }

--- a/Winch/Patches/API/WorldEventLoadPatcher.cs
+++ b/Winch/Patches/API/WorldEventLoadPatcher.cs
@@ -11,12 +11,12 @@ namespace Winch.Patches.API
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<WorldEventData>> handle)
         {
-            DredgeEvent.TriggerWorldEventsLoaded(__instance, handle, true);
+            DredgeEvent.AddressableEvents.WorldEventsLoaded.Trigger(__instance, handle, true);
         }
 
         public static void Postfix(DataLoader __instance, AsyncOperationHandle<IList<WorldEventData>> handle)
         {
-            DredgeEvent.TriggerWorldEventsLoaded(__instance, handle, false);
+            DredgeEvent.AddressableEvents.WorldEventsLoaded.Trigger(__instance, handle, false);
         }
     }
 }


### PR DESCRIPTION
An opinionated breakout of events from the single `DredgeEvent` class. I believe it can at least be more easily extended for many different classes of events that can now be patched in.