### PR TITLE
Use DredgeGameLibs instead of including DLLs from local install

### DIFF
--- a/Winch.Examples/DisasterButton/DisasterButton.csproj
+++ b/Winch.Examples/DisasterButton/DisasterButton.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net48</TargetFramework>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -21,26 +22,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="Assembly-CSharp.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Assembly-CSharp.dll" Private="False" />
-		<Reference Include="Assembly-CSharp-firstpass.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Assembly-CSharp-firstpass.dll" Private="False" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="UnityEngine.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.dll" Private="False" />
-		<Reference Include="UnityEngine.CoreModule.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.CoreModule.dll" Private="False" />
-		<Reference Include="UnityEngine.InputLegacyModule.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.InputLegacyModule.dll" Private="False" />
-		<Reference Include="UnityEngine.LocalizationModule.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.LocalizationModule.dll" Private="False" />
-		<Reference Include="Unity.ResourceManager.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Unity.ResourceManager.dll" Private="False" />
-		<Reference Include="Unity.Localization.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Unity.Localization.dll" Private="False" />
-		<Reference Include="Sirenix.Serialization.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Sirenix.Serialization.dll" Private="False" />
+		<PackageReference Include="DredgeGameLibs" Version="1.0.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="Assets\Localization\de.json">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="Assets\Localization\en.json">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="mod_meta.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Winch.Examples/ExampleItems/ExampleItems.csproj
+++ b/Winch.Examples/ExampleItems/ExampleItems.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net48</TargetFramework>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -14,11 +15,11 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -29,42 +30,31 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="Assembly-CSharp.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Assembly-CSharp.dll" Private="False" />
-		<Reference Include="Assembly-CSharp-firstpass.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Assembly-CSharp-firstpass.dll" Private="False" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="UnityEngine.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.dll" Private="False" />
-		<Reference Include="UnityEngine.CoreModule.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.CoreModule.dll" Private="False" />
-		<Reference Include="UnityEngine.InputLegacyModule.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.InputLegacyModule.dll" Private="False" />
-		<Reference Include="UnityEngine.LocalizationModule.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.LocalizationModule.dll" Private="False" />
-		<Reference Include="Unity.ResourceManager.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Unity.ResourceManager.dll" Private="False" />
-		<Reference Include="Unity.Localization.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Unity.Localization.dll" Private="False" />
-		<Reference Include="Sirenix.Serialization.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Sirenix.Serialization.dll" Private="False" />
+		<PackageReference Include="DredgeGameLibs" Version="1.0.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="Assets\Items\General\exampleitems.diamond.json">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="Assets\Localization\en.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="Assets\Textures\exampleitems.diamond.png">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="mod_meta.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 		<None Update="Assets\Items\Fish\exampleitems.mccod.json">
-		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
-    <None Update="Assets\Textures\exampleitems.mccod.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="Assets\Textures\exampleitems.mcicon.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+		<None Update="Assets\Textures\exampleitems.mccod.png">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="Assets\Textures\exampleitems.mcicon.png">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 
 </Project>

--- a/Winch.Examples/IntroSkipper/IntroSkipper.csproj
+++ b/Winch.Examples/IntroSkipper/IntroSkipper.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
-	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net48</TargetFramework>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
 
 	<PropertyGroup>
 		<DebugType>none</DebugType>
@@ -14,26 +15,20 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\..\Winch\Winch.csproj">
-	    <Private>False</Private>
-	    <CopyLocalSatelliteAssemblies>False</CopyLocalSatelliteAssemblies>
-	  </ProjectReference>
+		<ProjectReference Include="..\..\Winch\Winch.csproj">
+			<Private>False</Private>
+			<CopyLocalSatelliteAssemblies>False</CopyLocalSatelliteAssemblies>
+		</ProjectReference>
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="Assembly-CSharp.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Assembly-CSharp.dll" Private="False" />
-		<Reference Include="Assembly-CSharp-firstpass.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Assembly-CSharp-firstpass.dll" Private="False" />
+		<PackageReference Include="DredgeGameLibs" Version="1.0.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="UnityEngine.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.dll" Private="False" />
-		<Reference Include="UnityEngine.CoreModule.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.CoreModule.dll" Private="False" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Update="mod_meta.json">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
+		<None Update="mod_meta.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 
 </Project>

--- a/Winch.Examples/IntroSkipper/SplashControllerPatcher.cs
+++ b/Winch.Examples/IntroSkipper/SplashControllerPatcher.cs
@@ -4,7 +4,7 @@ using Winch.Core;
 namespace IntroSkipper
 {
     [HarmonyPatch(typeof(SplashController))]
-    [HarmonyPatch("OnEnable")]
+    [HarmonyPatch(nameof(SplashController.OnEnable))]
     class SplashControllerPatcher
     {
         public static bool Prefix()

--- a/Winch/Patches/API/AchievementLoadPatcher.cs
+++ b/Winch/Patches/API/AchievementLoadPatcher.cs
@@ -6,7 +6,7 @@ using Winch.Core.API;
 namespace Winch.Patches.API
 {
     [HarmonyPatch(typeof(AchievementManager))]
-    [HarmonyPatch("OnAchievementDataAddressablesLoaded")]
+    [HarmonyPatch(nameof(AchievementManager.OnAchievementDataAddressablesLoaded))]
     class AchievementLoadPatcher
     {
         public static void Prefix(AchievementManager __instance, AsyncOperationHandle<IList<AchievementData>> handle)

--- a/Winch/Patches/API/GridConfigsLoadPatcher.cs
+++ b/Winch/Patches/API/GridConfigsLoadPatcher.cs
@@ -6,7 +6,7 @@ using Winch.Core.API;
 namespace Winch.Patches.API
 {
     [HarmonyPatch(typeof(DataLoader))]
-    [HarmonyPatch("OnGridConfigDataAddressablesLoaded")]
+    [HarmonyPatch(nameof(DataLoader.OnGridConfigDataAddressablesLoaded))]
     class GridConfigsLoadPatcher
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<GridConfiguration>> handle)

--- a/Winch/Patches/API/ItemLoadPatcher.cs
+++ b/Winch/Patches/API/ItemLoadPatcher.cs
@@ -6,7 +6,7 @@ using Winch.Core.API;
 namespace Winch.Patches.API
 {
     [HarmonyPatch(typeof(ItemManager))]
-    [HarmonyPatch("OnItemDataAddressablesLoaded")]
+    [HarmonyPatch(nameof(ItemManager.OnItemDataAddressablesLoaded))]
     class ItemLoadPatcher
     {
         public static void Prefix(ItemManager __instance, AsyncOperationHandle<IList<ItemData>> handle)

--- a/Winch/Patches/API/MapMarkerLoadPatcher.cs
+++ b/Winch/Patches/API/MapMarkerLoadPatcher.cs
@@ -6,7 +6,7 @@ using Winch.Core.API;
 namespace Winch.Patches.API
 {
     [HarmonyPatch(typeof(DataLoader))]
-    [HarmonyPatch("OnMapMarkerDataAddressablesLoaded")]
+    [HarmonyPatch(nameof(DataLoader.OnMapMarkerDataAddressablesLoaded))]
     class MapMarkerLoadPatcher
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<MapMarkerData>> handle)

--- a/Winch/Patches/API/QuestGridLoadPatcher.cs
+++ b/Winch/Patches/API/QuestGridLoadPatcher.cs
@@ -6,7 +6,7 @@ using Winch.Core.API;
 namespace Winch.Patches.API
 {
     [HarmonyPatch(typeof(DataLoader))]
-    [HarmonyPatch("OnQuestGridDataAddressablesLoaded")]
+    [HarmonyPatch(nameof(DataLoader.OnQuestGridDataAddressablesLoaded))]
     class QuestGridLoadPatcher
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<QuestGridConfig>> handle)

--- a/Winch/Patches/API/UpgradeLoadPatcher.cs
+++ b/Winch/Patches/API/UpgradeLoadPatcher.cs
@@ -6,7 +6,7 @@ using Winch.Core.API;
 namespace Winch.Patches.API
 {
     [HarmonyPatch(typeof(UpgradeManager))]
-    [HarmonyPatch("OnUpgradeDataAddressablesLoaded")]
+    [HarmonyPatch(nameof(UpgradeManager.OnUpgradeDataAddressablesLoaded))]
     class UpgradeLoadPatcher
     {
         public static void Prefix(UpgradeManager __instance, AsyncOperationHandle<IList<UpgradeData>> handle)

--- a/Winch/Patches/API/WeatherDataLoadPatcher.cs
+++ b/Winch/Patches/API/WeatherDataLoadPatcher.cs
@@ -6,7 +6,7 @@ using Winch.Core.API;
 namespace Winch.Patches.API
 {
     [HarmonyPatch(typeof(DataLoader))]
-    [HarmonyPatch("OnWeatherDataAddressablesLoaded")]
+    [HarmonyPatch(nameof(DataLoader.OnWeatherDataAddressablesLoaded))]
     class WeatherDataLoadPatcher
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<WeatherData>> handle)

--- a/Winch/Patches/API/WorldEventLoadPatcher.cs
+++ b/Winch/Patches/API/WorldEventLoadPatcher.cs
@@ -6,7 +6,7 @@ using Winch.Core.API;
 namespace Winch.Patches.API
 {
     [HarmonyPatch(typeof(DataLoader))]
-    [HarmonyPatch("OnWorldEventDataAddressablesLoaded")]
+    [HarmonyPatch(nameof(DataLoader.OnWorldEventDataAddressablesLoaded))]
     class WorldEventLoadPatcher
     {
         public static void Prefix(DataLoader __instance, AsyncOperationHandle<IList<WorldEventData>> handle)

--- a/Winch/Patches/BuildInfoFeaturePatcher.cs
+++ b/Winch/Patches/BuildInfoFeaturePatcher.cs
@@ -4,7 +4,7 @@ using Winch.Core;
 namespace Winch.Patches
 {
     [HarmonyPatch(typeof(GameManager))]
-    [HarmonyPatch("AddTerminalCommands")]
+    [HarmonyPatch(nameof(GameManager.AddTerminalCommands))]
     class BuildInfoFeaturePatcher
     {
         static bool Prefix() {

--- a/Winch/Patches/GameLoadPatcher.cs
+++ b/Winch/Patches/GameLoadPatcher.cs
@@ -4,7 +4,7 @@ using Winch.Core;
 namespace Winch.Patches
 {
     [HarmonyPatch(typeof(GameManager))]
-    [HarmonyPatch("WaitForAllAsyncManagers")]
+    [HarmonyPatch(nameof(GameManager.WaitForAllAsyncManagers))]
     class GameLoadPatcher
     {
         static void Postfix()

--- a/Winch/Winch.csproj
+++ b/Winch/Winch.csproj
@@ -5,6 +5,7 @@
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 		<LangVersion>11</LangVersion>
+		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -20,33 +21,22 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="Assembly-CSharp.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Assembly-CSharp.dll" Private="False" />
-		<Reference Include="Assembly-CSharp-firstpass.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Assembly-CSharp-firstpass.dll" Private="False" />
+		<PackageReference Include="DredgeGameLibs" Version="1.0.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="Sirenix.Serialization.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Sirenix.Serialization.dll" Private="False" />
-		<Reference Include="System.Net.Http" HintPath="$(DredgePath)/DREDGE_Data/Managed/System.Net.Http.dll" Private="False" />
-		<Reference Include="UnityEngine.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.dll" Private="False" />
-		<Reference Include="UnityEngine.CoreModule.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.CoreModule.dll" Private="False" />
-		<Reference Include="UnityEngine.ImageConversionModule.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/UnityEngine.ImageConversionModule.dll" Private="False" />
-		<Reference Include="Unity.ResourceManager.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Unity.ResourceManager.dll" Private="False" />
-		<Reference Include="Unity.Localization.dll" HintPath="$(DredgePath)/DREDGE_Data/Managed/Unity.Localization.dll" Private="False" />
+		<Compile Update="Properties\Resources.Designer.cs">
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+			<DependentUpon>Resources.resx</DependentUpon>
+		</Compile>
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Compile Update="Properties\Resources.Designer.cs">
-	    <DesignTime>True</DesignTime>
-	    <AutoGen>True</AutoGen>
-	    <DependentUpon>Resources.resx</DependentUpon>
-	  </Compile>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <EmbeddedResource Update="Properties\Resources.resx">
-	    <Generator>ResXFileCodeGenerator</Generator>
-	    <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-	  </EmbeddedResource>
+		<EmbeddedResource Update="Properties\Resources.resx">
+			<Generator>ResXFileCodeGenerator</Generator>
+			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
+		</EmbeddedResource>
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Game libs are made with <https://github.com/xen-42/DredgeGameLibs> and then uploaded to NuGet with an action. I can add whoever as a collaborator on it since we have to manually run it locally on each game update, but the process is very simple.