### PR TITLE
Central config files

### DIFF
--- a/Winch/Config/JSONConfig.cs
+++ b/Winch/Config/JSONConfig.cs
@@ -9,6 +9,7 @@ namespace Winch.Config
     public class JSONConfig
     {
         private readonly Dictionary<string, object?> _config;
+        public Dictionary<string, object?> Config { get { return _config; } }
         private readonly string _configPath;
 
         public JSONConfig(string path, string defaultConfig) {

--- a/Winch/Config/ModConfig.cs
+++ b/Winch/Config/ModConfig.cs
@@ -34,6 +34,14 @@ namespace Winch.Config
             return output;
         }
 
+        public static Dictionary<string, object?> GetFullConfig(string modName, string fileName, string subDirectory)
+        {
+            string _path = Path.Combine(modName, subDirectory);
+            if (!Instances.ContainsKey(_path))
+                Instances.Add(_path, new ModConfig(_path, fileName));
+            return Instances[_path].Config;
+        }
+
         private static ModConfig GetConfig(string modName, string fileName, string subDirectory)
         {
             string _path = Path.Combine(modName, subDirectory);

--- a/Winch/Config/ModConfig.cs
+++ b/Winch/Config/ModConfig.cs
@@ -35,14 +35,6 @@ namespace Winch.Config
             return output;
         }
 
-        public static Dictionary<string, object?> GetFullConfig(string modName, string fileName = defaultConfigFile, string subDirectory = "")
-        {
-            string _path = Path.Combine(modName, subDirectory);
-            if (!Instances.ContainsKey(_path))
-                Instances.Add(_path, new ModConfig(_path, fileName));
-            return Instances[_path].Config;
-        }
-
         private static ModConfig GetConfig(string modName, string fileName, string subDirectory)
         {
             string _path = Path.Combine(modName, subDirectory);
@@ -54,6 +46,11 @@ namespace Winch.Config
         public static T? GetProperty<T>(string modName, string key, T? defaultValue, string fileName = defaultConfigFile, string subDirectory = "")
         {
             return GetConfig(modName, fileName, subDirectory).GetProperty(key, defaultValue);
+        }
+
+        public static Dictionary<string, object?> GetFullConfig(string modName, string fileName = defaultConfigFile, string subDirectory = "")
+        {
+            return GetConfig(modName, fileName, subDirectory).Config;
         }
 
         public static void RegisterDefaultConfig(string modName, string config)

--- a/Winch/Config/ModConfig.cs
+++ b/Winch/Config/ModConfig.cs
@@ -34,7 +34,7 @@ namespace Winch.Config
             return output;
         }
 
-        public static Dictionary<string, object?> GetFullConfig(string modName, string fileName, string subDirectory)
+        public static Dictionary<string, object?> GetFullConfig(string modName, string fileName, string subDirectory="")
         {
             string _path = Path.Combine(modName, subDirectory);
             if (!Instances.ContainsKey(_path))

--- a/Winch/Config/ModConfig.cs
+++ b/Winch/Config/ModConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Winch.Core;
@@ -9,6 +9,7 @@ namespace Winch.Config
     {
         private static Dictionary<string, string> DefaultConfigs = new Dictionary<string, string>();
         private static Dictionary<string, ModConfig> Instances = new Dictionary<string, ModConfig>();
+        private const string defaultConfigFile = "Config.json";
 
         private ModConfig(string modName, string fileName) : base(GetConfigPath(modName, fileName), GetDefaultConfig(modName))
         {
@@ -16,7 +17,7 @@ namespace Winch.Config
 
         private static string GetDefaultConfig(string modName)
         {
-            if(!DefaultConfigs.ContainsKey(modName))
+            if (!DefaultConfigs.ContainsKey(modName))
             {
                 WinchCore.Log.Debug($"No default config found for {modName}");
                 DefaultConfigs.Add(modName, "{}");
@@ -24,7 +25,7 @@ namespace Winch.Config
             return DefaultConfigs[modName];
         }
 
-        private static string GetConfigPath(string configLocation, string fileName="Config.json")
+        private static string GetConfigPath(string configLocation, string fileName)
         {
             string basePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Config");
             string output = Path.Combine(basePath, configLocation, fileName);
@@ -34,7 +35,7 @@ namespace Winch.Config
             return output;
         }
 
-        public static Dictionary<string, object?> GetFullConfig(string modName, string fileName, string subDirectory="")
+        public static Dictionary<string, object?> GetFullConfig(string modName, string fileName = defaultConfigFile, string subDirectory = "")
         {
             string _path = Path.Combine(modName, subDirectory);
             if (!Instances.ContainsKey(_path))
@@ -50,7 +51,7 @@ namespace Winch.Config
             return Instances[_path];
         }
 
-        public static T? GetProperty<T>(string modName, string key, T? defaultValue, string fileName="Config.json", string subDirectory="")
+        public static T? GetProperty<T>(string modName, string key, T? defaultValue, string fileName = defaultConfigFile, string subDirectory = "")
         {
             return GetConfig(modName, fileName, subDirectory).GetProperty(key, defaultValue);
         }

--- a/Winch/Config/ModConfig.cs
+++ b/Winch/Config/ModConfig.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using Winch.Core;
 
@@ -35,24 +34,12 @@ namespace Winch.Config
             return output;
         }
 
-        private static ModConfig GetConfig(string modName, string fileName)
-        {
-            if (!Instances.ContainsKey(modName))
-                Instances.Add(modName, new ModConfig(modName, fileName));
-            return Instances[modName];
-        }
-
         private static ModConfig GetConfig(string modName, string fileName, string subDirectory)
         {
             string _path = Path.Combine(modName, subDirectory);
             if (!Instances.ContainsKey(_path))
                 Instances.Add(_path, new ModConfig(_path, fileName));
             return Instances[_path];
-        }
-
-        public static T? GetProperty<T>(string modName, string key, T? defaultValue, string fileName="Config.json")
-        {
-            return GetConfig(modName, fileName).GetProperty(key, defaultValue);
         }
 
         public static T? GetProperty<T>(string modName, string key, T? defaultValue, string fileName="Config.json", string subDirectory="")

--- a/Winch/Config/ModConfig.cs
+++ b/Winch/Config/ModConfig.cs
@@ -26,10 +26,8 @@ namespace Winch.Config
 
         private static string GetConfigPath(string modName)
         {
-            return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Mods", modName, "Config.json");
+            return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Config", modName, "Config.json");
         }
-
-
 
         private static ModConfig GetConfig(string modName)
         {

--- a/Winch/Config/ModConfig.cs
+++ b/Winch/Config/ModConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Winch.Core;
 
@@ -10,7 +11,7 @@ namespace Winch.Config
         private static Dictionary<string, string> DefaultConfigs = new Dictionary<string, string>();
         private static Dictionary<string, ModConfig> Instances = new Dictionary<string, ModConfig>();
 
-        private ModConfig(string modName) : base(GetConfigPath(modName), GetDefaultConfig(modName))
+        private ModConfig(string modName, string fileName) : base(GetConfigPath(modName, fileName), GetDefaultConfig(modName))
         {
         }
 
@@ -18,27 +19,45 @@ namespace Winch.Config
         {
             if(!DefaultConfigs.ContainsKey(modName))
             {
-                WinchCore.Log.Error($"No 'DefaultConfig' attribute found in mod_meta.json for {modName}!");
-                throw new KeyNotFoundException($"No 'DefaultConfig' attribute found in mod_meta.json for {modName}!");
+                WinchCore.Log.Debug($"No default config found for {modName}");
+                DefaultConfigs.Add(modName, "{}");
             }
             return DefaultConfigs[modName];
         }
 
-        private static string GetConfigPath(string modName)
+        private static string GetConfigPath(string configLocation, string fileName="Config.json")
         {
-            return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Config", modName, "Config.json");
+            string basePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Config");
+            string output = Path.Combine(basePath, configLocation, fileName);
+            if (Directory.Exists(Path.Combine(basePath, configLocation)))
+                return output;
+            Directory.CreateDirectory(Path.Combine("Config", configLocation));
+            return output;
         }
 
-        private static ModConfig GetConfig(string modName)
+        private static ModConfig GetConfig(string modName, string fileName)
         {
             if (!Instances.ContainsKey(modName))
-                Instances.Add(modName, new ModConfig(modName));
+                Instances.Add(modName, new ModConfig(modName, fileName));
             return Instances[modName];
         }
 
-        public static T? GetProperty<T>(string modName, string key, T? defaultValue)
+        private static ModConfig GetConfig(string modName, string fileName, string subDirectory)
         {
-            return GetConfig(modName).GetProperty(key, defaultValue);
+            string _path = Path.Combine(modName, subDirectory);
+            if (!Instances.ContainsKey(_path))
+                Instances.Add(_path, new ModConfig(_path, fileName));
+            return Instances[_path];
+        }
+
+        public static T? GetProperty<T>(string modName, string key, T? defaultValue, string fileName="Config.json")
+        {
+            return GetConfig(modName, fileName).GetProperty(key, defaultValue);
+        }
+
+        public static T? GetProperty<T>(string modName, string key, T? defaultValue, string fileName="Config.json", string subDirectory="")
+        {
+            return GetConfig(modName, fileName, subDirectory).GetProperty(key, defaultValue);
         }
 
         public static void RegisterDefaultConfig(string modName, string config)

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -46,6 +46,11 @@ namespace Winch.Core
 
             CheckCompatibility();
 
+            string modConfig = Path.Combine("Config", Path.GetFileName(BasePath));
+            WinchCore.Log.Debug($"Checking path: {modConfig}");
+            if (!Directory.Exists(modConfig))
+                Directory.CreateDirectory(modConfig);
+
             WinchCore.Log.Debug($"Loaded Assembly '{LoadedAssembly.GetName().Name}'.");
         }
 

--- a/Winch/Core/ModAssemblyLoader.cs
+++ b/Winch/Core/ModAssemblyLoader.cs
@@ -17,6 +17,9 @@ namespace Winch.Core
             if (!Directory.Exists("Mods"))
                 Directory.CreateDirectory("Mods");
 
+            if (!Directory.Exists("Config"))
+                Directory.CreateDirectory("Config");
+
             string[] modDirs = Directory.GetDirectories("Mods");
             WinchCore.Log.Info($"Loading {modDirs.Length} mod assemblies...");
             foreach (string modDir in modDirs)

--- a/Winch/Util/ItemUtil.cs
+++ b/Winch/Util/ItemUtil.cs
@@ -25,7 +25,8 @@ internal static class ItemUtil
         { typeof(DamageItemData), new DamageItemDataConverter() },
     };
 
-    public static Dictionary<string, ItemData> HarvestableItemDataDict = new();
+    public static Dictionary<string, ItemData> harvestableItemDataDict = new();
+    public static Dictionary<string, ItemData> allItemDataDict = new();
 
     public static void PopulateItemData()
     {
@@ -33,9 +34,11 @@ internal static class ItemUtil
         {
             if (item is FishItemData or RelicItemData or HarvestableItemData)
             {
-                HarvestableItemDataDict.Add(item.id, item);
+                harvestableItemDataDict.Add(item.id, item);
+                WinchCore.Log.Debug($"Added item {item.id} to harvestableItemDataDict");
             }
-            WinchCore.Log.Debug($"Added item {item.id} to HarvestableItemDataDict");
+            allItemDataDict.Add(item.id, item);
+            WinchCore.Log.Debug($"Added item {item.id} to allItemDataDict");
         }
     }
 
@@ -47,8 +50,16 @@ internal static class ItemUtil
             WinchCore.Log.Error($"Meta file {metaPath} is empty");
             return;
         }
+        if (allItemDataDict.ContainsKey((string)meta["id"]))
+        {
+            WinchCore.Log.Error($"Duplicate item {(string)meta["id"]} at {metaPath} failed to load");
+            return;
+        }
         var item = UtilHelpers.GetScriptableObjectFromMeta<T>(meta, metaPath);
         if (UtilHelpers.PopulateObjectFromMeta<T>(item, meta, Converters))
+        {
             GameManager.Instance.ItemManager.allItems.Add(item);
+            allItemDataDict.Add(item.id, item);
+        }
     }
 }

--- a/Winch/Util/ItemUtil.cs
+++ b/Winch/Util/ItemUtil.cs
@@ -59,7 +59,6 @@ internal static class ItemUtil
         if (UtilHelpers.PopulateObjectFromMeta<T>(item, meta, Converters))
         {
             GameManager.Instance.ItemManager.allItems.Add(item);
-            allItemDataDict.Add(item.id, item);
         }
     }
 }


### PR DESCRIPTION
Improves ease of access, users can know that configs will always be in one specific place and easy to distinguish.
Allows for config files for mods when .zip mod loading is implemented. without cluttering the `/Mods` folder.

However, should at some point add some extent of utilities to allow for separating config out into separate folders and files within the mod-specific directory to keep things usable.