### PR TITLE
Add GameSceneInitialerStart event plus a little cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Rider cache/config directory
+.idea/

--- a/Winch/Core/API/DredgeEvent.cs
+++ b/Winch/Core/API/DredgeEvent.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using Winch.Core.API.Events;
 using Winch.Core.API.Events.Addressables;
-using Winch.Core.API.Events.POI;
 using Winch.Core.API.Events.Scene;
 
 namespace Winch.Core.API

--- a/Winch/Core/API/DredgeEvent.cs
+++ b/Winch/Core/API/DredgeEvent.cs
@@ -1,11 +1,15 @@
 ﻿using System;
+using Winch.Core.API.Events;
 using Winch.Core.API.Events.Addressables;
+using Winch.Core.API.Events.POI;
+using Winch.Core.API.Events.Scene;
 
 namespace Winch.Core.API
 {
     public static class DredgeEvent
     {
-        public static AddressableEvents AddressableEvents = new AddressableEvents();
+        public static AddressableEvents AddressableEvents = new();
+        public static SceneEvents SceneEvents = new();
 
         public static event EventHandler? ManagersLoaded;
         public static void TriggerManagersLoaded()

--- a/Winch/Core/API/Events/Addressables/AddressableEvents.cs
+++ b/Winch/Core/API/Events/Addressables/AddressableEvents.cs
@@ -2,22 +2,14 @@
 {
     public class AddressableEvents
     {
-        public AddressablesLoadedHook<AchievementData> AchievementsLoaded = new AddressablesLoadedHook<AchievementData>();
-
-        public AddressablesLoadedHook<GridConfiguration> GridConfigsLoaded = new AddressablesLoadedHook<GridConfiguration>();
-
-        public AddressablesLoadedHook<ItemData> ItemsLoaded = new AddressablesLoadedHook<ItemData>();
-
-        public AddressablesLoadedHook<MapMarkerData> MapMarkersLoaded = new AddressablesLoadedHook<MapMarkerData>();
-
-        public AddressablesLoadedHook<QuestData> QuestsLoaded = new AddressablesLoadedHook<QuestData>();
-
-        public AddressablesLoadedHook<QuestGridConfig> QuestGridConfigsLoaded = new AddressablesLoadedHook<QuestGridConfig>();
-
-        public AddressablesLoadedHook<UpgradeData> UpgradesLoaded = new AddressablesLoadedHook<UpgradeData>();
-
-        public AddressablesLoadedHook<WeatherData> WeatherDataLoaded = new AddressablesLoadedHook<WeatherData>();
-
-        public AddressablesLoadedHook<WorldEventData> WorldEventsLoaded = new AddressablesLoadedHook<WorldEventData>();
+        public AddressablesLoadedHook<AchievementData> AchievementsLoaded = new();
+        public AddressablesLoadedHook<GridConfiguration> GridConfigsLoaded = new();
+        public AddressablesLoadedHook<ItemData> ItemsLoaded = new();
+        public AddressablesLoadedHook<MapMarkerData> MapMarkersLoaded = new();
+        public AddressablesLoadedHook<QuestData> QuestsLoaded = new();
+        public AddressablesLoadedHook<QuestGridConfig> QuestGridConfigsLoaded = new();
+        public AddressablesLoadedHook<UpgradeData> UpgradesLoaded = new();
+        public AddressablesLoadedHook<WeatherData> WeatherDataLoaded = new();
+        public AddressablesLoadedHook<WorldEventData> WorldEventsLoaded = new();
     }
 }

--- a/Winch/Core/API/Events/Addressables/AddressablesLoadedEventHandler.cs
+++ b/Winch/Core/API/Events/Addressables/AddressablesLoadedEventHandler.cs
@@ -1,4 +1,0 @@
-﻿namespace Winch.Core.API.Events.Addressables
-{
-    public delegate void AddressablesLoadedEventHandler<T>(object sender, AddressablesLoadedEventArgs<T> e);
-}

--- a/Winch/Core/API/Events/DelegateDefinitions.cs
+++ b/Winch/Core/API/Events/DelegateDefinitions.cs
@@ -1,0 +1,7 @@
+﻿using Winch.Core.API.Events.Addressables;
+
+namespace Winch.Core.API.Events;
+
+public delegate void DelegateDefinitions<T>(T instance);
+public delegate void AddressablesLoadedEventHandler<T>(object sender, AddressablesLoadedEventArgs<T> e);
+public delegate void ArbitraryEventHandler<T>(params object[] parameters);

--- a/Winch/Core/API/Events/InstanceOnlyHook.cs
+++ b/Winch/Core/API/Events/InstanceOnlyHook.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using UnityEngine.EventSystems;
+
+namespace Winch.Core.API.Events;
+
+public class InstanceOnlyHook<T>
+{
+    public event DelegateDefinitions<T> Before;
+    public event DelegateDefinitions<T> On;
+
+    public void Trigger(T instance, bool prefix)
+    {
+
+        WinchCore.Log.Debug($"Triggered instance {typeof(T)} event : (Prefix: {prefix.ToString()})");
+        try
+        {
+            if (prefix)
+                Before?.Invoke(instance);
+            else
+                On?.Invoke(instance);
+        }
+        catch (Exception ex)
+        {
+            WinchCore.Log.Error($"Failed to trigger instance {typeof(T)} types event: {ex}");
+        }
+
+    }
+}

--- a/Winch/Core/API/Events/Scene/SceneEvents.cs
+++ b/Winch/Core/API/Events/Scene/SceneEvents.cs
@@ -1,0 +1,6 @@
+﻿namespace Winch.Core.API.Events.Scene;
+
+public class SceneEvents
+{
+    public InstanceOnlyHook<GameSceneInitializer> GameSceneInitializerStart = new();
+}

--- a/Winch/Core/AssetLoader.cs
+++ b/Winch/Core/AssetLoader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.IO;
+using System.Reflection;
 using Winch.Util;
 
 namespace Winch.Core
@@ -72,7 +73,7 @@ namespace Winch.Core
                 {
                     genericMethod.Invoke(null, new object[] { item.Value });
                 }
-                
+
             }
         }
 
@@ -81,7 +82,7 @@ namespace Winch.Core
             string autoMovePoiPath = Path.Combine(conversationPoiFolderPath, "AutoMove");
             string explosivePoiPath = Path.Combine(conversationPoiFolderPath, "Explosive");
             string inspectPoiPath = Path.Combine(conversationPoiFolderPath, "Inspect");
-            
+
             if (Directory.Exists(autoMovePoiPath)) LoadPoiFilesOfType<AutoMovePOI>(autoMovePoiPath);
             if (Directory.Exists(explosivePoiPath)) LoadPoiFilesOfType<ExplosivePOI>(explosivePoiPath);
             if (Directory.Exists(inspectPoiPath)) LoadPoiFilesOfType<InspectPOI>(inspectPoiPath);

--- a/Winch/Patches/API/GameSceneInitializerPatcher.cs
+++ b/Winch/Patches/API/GameSceneInitializerPatcher.cs
@@ -1,0 +1,18 @@
+﻿using HarmonyLib;
+using Winch.Core.API;
+
+namespace Randomizer.Patchers;
+
+[HarmonyPatch(typeof(GameSceneInitializer))]
+[HarmonyPatch("Start")]
+public class GameSceneInitializerPatcher
+{
+    public static void Prefix(GameSceneInitializer __instance)
+    {
+        DredgeEvent.SceneEvents.GameSceneInitializerStart.Trigger(__instance, true);
+    }
+    public static void Postfix(GameSceneInitializer __instance)
+    {
+        DredgeEvent.SceneEvents.GameSceneInitializerStart.Trigger(__instance, false);
+    }
+}


### PR DESCRIPTION
Just added an event to hook into for when the game scene initializes. It's useful to be able to access and modify loaded game objects at a macro scale (rather than patching something into one of their component functions).

I introduced a new hook type that only cares about the sender (but the type matters rather than passing an object). I want to consolidate our hook definitions where we can use a variable set of parameters as defined by a custom EventArgs but that will come in a later PR