### PR TITLE
poi file set to "copy always" in ExampleItems

### DIFF
--- a/Winch.Examples/ExampleItems/ExampleItems.csproj
+++ b/Winch.Examples/ExampleItems/ExampleItems.csproj
@@ -40,6 +40,9 @@
 		<None Update="Assets\Localization\en.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+		<None Update="Assets\POI\Harvest\exampleitems.exampleharvestpoi.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 		<None Update="Assets\Textures\exampleitems.diamond.png">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>


### PR DESCRIPTION
ExampleItems poi file is set to not copy on build. the rest of the files in example directory are set to copy.